### PR TITLE
Removing dest='fuct' from Subparsers

### DIFF
--- a/ssm-diff
+++ b/ssm-diff
@@ -69,7 +69,7 @@ if __name__ == "__main__":
     parser.add_argument('-f', help='local state yml file', action='store', dest='filename')
     parser.add_argument('--engine', '-e', help='diff engine to use when interacting with SSM', action='store', dest='engine', default='DiffResolver')
     parser.add_argument('--profile', help='AWS profile name', action='store', dest='profile')
-    subparsers = parser.add_subparsers(dest='func', help='commands')
+    subparsers = parser.add_subparsers(help='commands')
     subparsers.required = True
 
     parser_init= subparsers.add_parser('clone', help='create a local copy of the remote storage')


### PR DESCRIPTION
I noticed the other day ssm-diff is broken in python 3.9, I haven't tried other versions of python to know if this is backwards compatible. Just offering this PR in case you've bumped into this.

In python 3.9 running subcommands results in:

```
Traceback (most recent call last):
  File "C:\Users\Sebastiaan\git\ssm-diff\ssm-diff", line 117, in <module>
    args.func(args)
TypeError: 'str' object is not callable
```

Removing dest='func' gets around this.